### PR TITLE
Adding rough security test proto

### DIFF
--- a/pocket/security-test/Dockerfile
+++ b/pocket/security-test/Dockerfile
@@ -1,0 +1,9 @@
+# SEE https://github.com/zaproxy/zaproxy/issues/1880#issuecomment-142677598
+
+FROM owasp/zap2docker-stable
+MAINTAINER grunny
+
+RUN pip install --upgrade git+https://github.com/Grunny/zap-cli.git
+
+RUN chown -R zap /zap/
+ENV ZAP_PORT 8080

--- a/pocket/security-test/Makefile
+++ b/pocket/security-test/Makefile
@@ -1,0 +1,5 @@
+build_docker:
+	docker build -t zap-cli .
+
+run_docker: build_docker
+	docker run -u zap -i zap-cli zap-cli quick-scan -sc -o "-config api.disablekey=true" -s xss "$(url)"

--- a/pocket/security-test/run.sh
+++ b/pocket/security-test/run.sh
@@ -1,0 +1,12 @@
+# grab test manifest by product type:
+#   curl -O https://raw.githubusercontent.com/mozilla-services/services-test/master/{{product}}/manifest.json
+# test_type == security
+# env == 'dev' | 'stage' | 'pre-prod' | 'prod' (but probably not prod ever)
+
+if [ "$#" -ne 1 ]; then
+  echo "Illegal number of parameters"
+  echo "Usage: $ $0 {{url}}"
+  exit
+fi
+
+make url="$1" run_docker


### PR DESCRIPTION
Uses the Docker-ized version of ZAProxy (with a Makefile to help smooth out the rough edges of Docker commands).

Usage: `$ ./run.sh http://example.com`

This currently violates our policy that you should just be able to invoke ./run.sh from a directory (by introducing mandatory command line args).

@rpappalax suggests that I/we grab the manifest.json for the current directory/project, and then grab the URL for the specified test type (which is "security" or "security-test"), as well as the current test environment (which is "stage", "pre-prod", or "prod"). So we may also need to tweak the manifest.json file to explicitly mention URLs that we want to run the ZAProxy scanner against.
