### PR TITLE
update for jenkins integration

### DIFF
--- a/sync/e2e-test/run
+++ b/sync/e2e-test/run
@@ -2,7 +2,7 @@
 
 ## these will be added by Vagrant and the nightly refresh job
 # sudo apt-get -y install mercurial
-hg clone http://hg.mozilla.org/mozilla-central
+#hg clone http://hg.mozilla.org/mozilla-central
 # cd mozilla-central/testing/tps
 
 # tweak these:


### PR DESCRIPTION
r? @karlht 
remove hg clone mozilla-central (now being done by daily maintenance job).
rename run.sh to run.

Closes #76 

:dancer: 
