### PR TITLE
Add push dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,23 +12,24 @@ Repo Structure
 ----------------------
 To contribute a new automated test to the services-test repo, please adhere to the following guidelines.  This following file structure is required by Jenkins to execute automated tests.
 
-* __project__ (directory)
- * One directory per project.  For example:
-   * services-test/absearch
-   * services-test/autopush, etc.
-* __README.md__ (file) 
+* {__project__}/
+  * One directory per project.  For example:
+    * services-test/absearch
+    * services-test/autopush
+    * etc.
+* {__project__}/__README.md__
  * Add README file in project folder with links to: project repo (github), readthedocs, testplan, etc. 
-* __test-type__ (directory)
+* {__project__}/{__test-type__}/
  * One project child directory per test-type.  For example:
   * services-test/absearch/e2e-test
   * services-test/absearch/schema-check, etc.
-* __run__ (file)
+* {__project__}/{__test-type__}/__run__
  * Add a "run" file in each test-type directory which should install all dependencies and kick off a test of the type indicated by the parent directory
  * example: [example run file](/demo/e2e-test/run)
-* __manifest.ini__ (file)
+* {__project__}/{__test-type__}/__manifest.ini__
  * Add a manifest file in each test-type directory which should specify any environment-specific parameters
   * example: [example manifest.ini](/demo/e2e-test/manifest.ini)
-* __misc__ (files)
+* {__project__}/{__test-type__}/__*__
  * Any additional files needed by that test type should be self-contained in that directory.
 
 Docker Instructions
@@ -56,7 +57,7 @@ docker run -it -v /Users/your-username/path/to/services-qa-secrets/secrets:/secr
 Test Manifests
 ----------------------
 
-A "test manifest" (manifest.json) ican be found in each project directory.
+A "test manifest" (manifest.json) can be found in each project directory.
 This file specifies all the test types:
 tag-check, stack-check, e2e-test, etc. that will be run in any given
 test environment: stage, pre-prod, prod, etc.

--- a/push-dashboard/e2e-test/manifest.ini
+++ b/push-dashboard/e2e-test/manifest.ini
@@ -1,0 +1,9 @@
+[DEFAULT]
+label = UBUNTU-DESKTOP
+job_timeout = 5
+
+[dev]
+url_endpoint = https://dev-dashboard.deis.mozaws.net/
+
+[stage]
+url_endpoint = https://pushdevdashboard-default.stage.mozaws.net/

--- a/push-dashboard/e2e-test/run
+++ b/push-dashboard/e2e-test/run
@@ -1,0 +1,7 @@
+#!/bin/bash +x
+
+rm -rf push-dev-dashboard
+git clone https://github.com/mozilla-services/push-dev-dashboard.git
+cd push-dev-dashboard
+pip install -r requirements-test.txt
+python manage.py test -v2 dashboard.tests.test_e2e


### PR DESCRIPTION
the `e2e-test/run` will need these environment variables set:
- `DJANGO_DEBUG_TOOLBAR=False`
- `TESTING_SITE` - what domain/site to test
- `TESTING_WEBDRIVER_TIMEOUT` - this defaults to 0 so that the selenium webdriver tests don't run during unit test run
- `TESTING_FXA_ACCOUNT_EMAIL` - pre-existing FxA account email
- `TESTING_FXA_ACCOUNT_PASSWORD` - pre-existing FxA account password
