### PR TITLE
explicitly choose firefox-nightly

### DIFF
--- a/sync/e2e-test/run
+++ b/sync/e2e-test/run
@@ -12,6 +12,7 @@
 # TODO: pull this from  manifest.ini
 LOG_FILE=tps_logs.txt
 ERROR_FLAGS="FAIL|ERROR|WTF"
+HOME_JENKINS="/home/jenkins-slave"
 
 if [ ! -d /home/jenkins-slave/mozilla-central ];then
    @echo "MOZILLA-CENTRAL not available"
@@ -32,5 +33,6 @@ cd $PWD/mozilla-central/testing/tps || exit 1
 . $HOME/tps-env/bin/activate
 Xvfb :20 >& ${WORKSPACE}/xerrors &
 export DISPLAY=:20
-runtps --binary=/usr/bin/firefox
+#runtps --binary=/usr/bin/firefox
+runtps --binary="${HOME_JENKINS}/firefox-nightly"
 pkill -f :20


### PR DESCRIPTION
We'll need to eventually move HOME_JENKINS to a global (or something), but this should work for now.
r? @karlht 
