### PR TITLE
Simplify the prefs set in the end-to-end tests

### DIFF
--- a/shavar/e2e-test/prefs.ini
+++ b/shavar/e2e-test/prefs.ini
@@ -3,13 +3,18 @@
 ################################
 
 [DEFAULT]
-browser.startup.homepage = http://itisatrap.org/firefox/its-a-tracker.html 
+browser.startup.homepage = http://itisatrap.org/firefox/its-a-tracker.html
 browser.safebrowsing.debug = true
 browser.safebrowsing.enabled = false
 browser.safebrowsing.malware.enabled = false
 privacy.trackingprotection.enabled = true
 browser.safebrowsing.provider.mozilla.nextupdatetime = 1
-#private.browsing.autostart = true
+browser.safebrowsing.provider.mozilla.gethashURL = ""
+
+# For these prefs, the values need to be ADDED to the existing ones
+# instead of overwriting the existing values.
+browser.safebrowsing.provider.mozilla.lists += mozpub-track-digest256,moztestpub-track-digest256,moztestpub-trackwhite-digest256,mozstdstaging-track-digest256,mozfullstaging-track-digest256,mozstdstaging-trackwhite-digest256
+urlclassifier.disallow_completions += mozpub-track-digest256,moztestpub-track-digest256,moztestpub-trackwhite-digest256,mozstdstaging-track-digest256,mozfullstaging-track-digest256,mozstdstaging-trackwhite-digest256
 
 
 ################################
@@ -17,15 +22,12 @@ browser.safebrowsing.provider.mozilla.nextupdatetime = 1
 ################################
 
 [stage]
-browser.safebrowsing.provider.mozilla.gethashURL = https://shavar.stage.mozaws.net/gethash?client=SAFEBROWSING_ID&appver=%VERSION%&pver=2.2
 browser.safebrowsing.provider.mozilla.updateURL = https://shavar.stage.mozaws.net/downloads?client=SAFEBROWSING_ID&appver=%VERSION%&pver=2.2
 
 [pre-prod]
-browser.safebrowsing.provider.mozilla.gethashURL = https://shavar.prod.mozaws.net/gethash?client=SAFEBROWSING_ID&appver=%VERSION%&pver=2.2
 browser.safebrowsing.provider.mozilla.updateURL = https://shavar.prod.mozaws.net/downloads?client=SAFEBROWSING_ID&appver=%VERSION%&pver=2.2
 
 [prod]
-browser.safebrowsing.provider.mozilla.gethashURL = https://shavar.services.mozilla.com/gethash?client=SAFEBROWSING_ID&appver=%VERSION%&pver=2.2
 browser.safebrowsing.provider.mozilla.updateURL = https://shavar.services.mozilla.com/downloads?client=SAFEBROWSING_ID&appver=%VERSION%&pver=2.2
 
 
@@ -36,29 +38,19 @@ browser.safebrowsing.provider.mozilla.updateURL = https://shavar.services.mozill
 [mozpub]      # PROD ONLY
 urlclassifier.trackingTable = test-track-simple,mozpub-track-digest256
 urlclassifier.trackingWhitelistTable = test-trackwhite-simple
-urlclassifier.disallow_completions = test-malware-simple,test-phish-simple,test-unwanted-simple,test-track-simple,test-trackwhite-simple,goog-downloadwhite-digest256,mozpub-track-digest256
-browser.safebrowsing.provider.mozilla.lists = mozpub-track-digest256
 
 [moztestpub]  # STAGE ONLY
 urlclassifier.trackingTable = test-track-simple,moztestpub-track-digest256
 urlclassifier.trackingWhitelistTable = test-trackwhite-simple,moztestpub-trackwhite-digest256
-urlclassifier.disallow_completions = test-malware-simple,test-phish-simple,test-unwanted-simple,test-track-simple,test-trackwhite-simple,goog-downloadwhite-digest256,moztestpub-track-digest256,moztestpub-trackwhite-digest256
-browser.safebrowsing.provider.mozilla.lists = moztestpub-track-digest256,moztestpub-trackwhite-digest256
 
 [mozstd]
 urlclassifier.trackingTable = test-track-simple,mozstd-track-digest256
 urlclassifier.trackingWhitelistTable = test-trackwhite-simple,mozstd-trackwhite-digest256
-urlclassifier.disallow_completions = test-malware-simple,test-phish-simple,test-unwanted-simple,test-track-simple,test-trackwhite-simple,goog-downloadwhite-digest256,mozstd-track-digest256,mozstd-trackwhite-digest256
-browser.safebrowsing.provider.mozilla.lists = mozstd-track-digest256,mozstd-trackwhite-digest256
 
 [mozstaging]
 urlclassifier.trackingTable = test-track-simple,mozstdstaging-track-digest256,mozfullstaging-track-digest256
 urlclassifier.trackingWhitelistTable = test-trackwhite-simple,mozstdstaging-trackwhite-digest256
-urlclassifier.disallow_completions = test-malware-simple,test-phish-simple,test-unwanted-simple,test-track-simple,test-trackwhite-simple,goog-downloadwhite-digest256,mozstdstaging-track-digest256,mozfullstaging-track-digest256,mozstdstaging-trackwhite-digest256
-browser.safebrowsing.provider.mozilla.lists = mozstdstaging-track-digest256,mozfullstaging-track-digest256,mozstdstaging-trackwhite-digest256
 
 [mozfull]
 urlclassifier.trackingTable = test-track-simple,mozfull-track-digest256
 urlclassifier.trackingWhitelistTable = test-trackwhite-simple,mozstd-trackwhite-digest256
-urlclassifier.disallow_completions = test-malware-simple,test-phish-simple,test-unwanted-simple,test-track-simple,test-trackwhite-simple,goog-downloadwhite-digest256,mozfull-track-digest256,mozstd-trackwhite-digest256
-browser.safebrowsing.provider.mozilla.lists = mozfull-track-digest256,mozstd-trackwhite-digest256


### PR DESCRIPTION
@rpappalax This should work around https://bugzilla.mozilla.org/show_bug.cgi?id=1274685 and also removes the gethash URLs since we're not using that for any of our lists yet.
