### PR TITLE
New Loop server version switch

### DIFF
--- a/loop/config-check/test_config_check.py
+++ b/loop/config-check/test_config_check.py
@@ -43,7 +43,7 @@ def test_server_config(conf, env):
     assert json_dict['fxosApp']['name'] == conf.get(env, 'loop_fxos_app_name')
 
 
-def test_server_response(conf, env):
+def test_server_response(conf, env, server_version):
     r = requests.get(conf.get(env, 'loop_server'))
     data = r.json()
 
@@ -54,7 +54,7 @@ def test_server_response(conf, env):
     assert data['homepage'] == conf.get(env, 'homePage')
     assert 'i18n' in data
     assert data['name'] == conf.get(env, 'name')
-    assert data['version'] == conf.get(env, 'loop_server_version')
+    assert data['version'] == server_version
 
 
 def test_push_server_config(conf, env):

--- a/loop/conftest.py
+++ b/loop/conftest.py
@@ -8,8 +8,18 @@ def pytest_addoption(parser):
         action="store",
         help="choose a test environment: staging or production"
     )
+    parser.addoption(
+        "--server-version",
+        action="store",
+        help="Version of Loop server we are testing"
+    )
 
 
 @pytest.fixture
 def env(request):
     return request.config.getoption("--env")
+
+
+@pytest.fixture
+def server_version(request):
+    return request.config.getoption("--server-version")

--- a/loop/manifest.ini
+++ b/loop/manifest.ini
@@ -2,7 +2,6 @@
 location =  https://www.mozilla.org/firefox/hello/
 root = https://call.stage.mozaws.net
 loop_server = https://loop.stage.mozaws.net
-loop_server_version = 0.21.1
 loop_server_push_server_config = https://loop.stage.mozaws.net/push-server-config
 loop_server_push_server_uri = wss://autopush.stage.mozaws.net
 loop_fxos_app_name = Hello Stage
@@ -17,4 +16,22 @@ homePage = https://github.com/mozilla-services/loop-server/
 fakeTokBox = False
 fxaOAuth = True
 name = mozilla-loop-server
-version = 0.21.1
+
+[production]
+location =  https://www.mozilla.org/firefox/hello/
+root = https://hello.firefox.com
+loop_server = https://loop.services.mozilla.com
+loop_server_push_server_config = https://loop.services.mozilla.com/push-server-config
+loop_server_push_server_uri = wss://push.services.mozilla.com
+loop_fxos_app_name = Firefox Hello
+feedbackProductName = Loop
+privacyWebsiteUrl = https://www.mozilla.org/privacy/firefox-hello/
+legalWebsiteUrl = https://www.mozilla.org/about/legal/terms/firefox-hello/
+roomsSupportUrl = https://support.mozilla.org/kb/group-conversations-firefox-hello-webrtc
+guestSupportUrl = https://support.mozilla.org/kb/respond-firefox-hello-invitation-guest-mode
+unsupportedPlatformUrl = https://support.mozilla.org/kb/which-browsers-will-work-firefox-hello-video-chat
+learnMoreUrl = https://www.mozilla.org/hello/
+homePage = https://github.com/mozilla-services/loop-server/
+fakeTokBox = False
+fxaOAuth = True
+name = mozilla-loop-server


### PR DESCRIPTION
@rpappalax ?
Added in a command-line switch so that we can specify the version of loop server that is supposed to be installed on the server we running the 'check-config' scripts against. Here's it's usage:

`py.test -v --env=production --server-version=0.21.3 config-check`
